### PR TITLE
Add AI chat responses with history

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -17,26 +17,37 @@ openai.api_key = OPENAI_API_KEY
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text("Привет! Я твой бот.")
+    context.chat_data["messages"] = []
+
+
+async def reset(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    context.chat_data.clear()
+    await update.message.reply_text("Диалог сброшен")
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.message is None or update.message.text is None:
         return
 
-    prompt = update.message.text
+    user_msg = update.message.text
+    history = context.chat_data.setdefault("messages", [])
+    history.append({"role": "user", "content": user_msg})
+
     try:
         response = openai.chat.completions.create(
             model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
+            messages=history,
         )
-        text = response.choices[0].message.content.strip()
+        bot_msg = response.choices[0].message.content.strip()
+        history.append({"role": "assistant", "content": bot_msg})
     except Exception as e:  # pragma: no cover - network failure
-        text = f"Ошибка при обращении к AI: {e}"
+        bot_msg = f"Ошибка при обращении к AI: {e}"
 
-    await update.message.reply_text(text)
+    await update.message.reply_text(bot_msg)
 
 if __name__ == "__main__":
     app = ApplicationBuilder().token(TOKEN).build()
     app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("reset", reset))
     app.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), handle_message))
     app.run_polling()


### PR DESCRIPTION
## Summary
- make `start` initialize chat history
- add `/reset` command to clear conversation
- track message history so OpenAI can reply with context

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(fails: InvalidToken)*

------
https://chatgpt.com/codex/tasks/task_e_68461070ba948325b38e3b526919562b